### PR TITLE
Animation loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,15 @@ Ta da! Read the walkthrough up above and the source for more options about all t
 - My animation is jumping all over the place. What's going on?
 
   You probably are passing a value as a string instead of a numeric value. Make sure your numbers are numbers!
+
+- The animation timing is too fast/too slow. Can I change it?
+
+  You bet! For the `<Animator>` component, just pass a `duration` prop with the number of ms you'd like it to take. Here's 10 seconds.
+
+      <Animator values={["width"]} duration = {10000} >...</Animator>
+
+  For the `useInterpolate` hook, the third argument is an options object. Pass duration there.
+
+      ...
+      useInterpolate(width, setInterpolatedWidth, { duration : 10000})
+      ...

--- a/src/Animation.js
+++ b/src/Animation.js
@@ -23,6 +23,7 @@ const Animation = ({
   easing = {},
   defaultEasing = animatorDefaultEasing,
   initial = {},
+  loop = 0,
 }) => {
   // given our values array, look to the child to figure out our current values.
   const current = values.reduce((bucket, v) => {
@@ -57,6 +58,8 @@ const Animation = ({
     duration,
 
     initial: fullInitial,
+
+    loop,
 
     // our getDelta function needs to construct a new object with each value interpolated
     // along the way.

--- a/src/useInterpolate.js
+++ b/src/useInterpolate.js
@@ -41,6 +41,13 @@ import { useRef, useEffect } from "react"
       than the one initially set on the component when it is first mounted.
       You can pass in a set of initial values to use here.
 
+    loop - repeat the animation from the beginning the specified number of times.
+      e.g., 5 repeats 5x, 10 repeats 10x.
+      0 is the default where it will not repeat.
+      -1 repeats infinite times.
+
+      Again, rememeber, it loops from the beginning.
+
 */
 
 /*
@@ -72,6 +79,7 @@ const useInterpolate = (
     duration = 500,
     getHasChanges = defaultHasChanges,
     initial,
+    loop = 0,
   } = {}
 ) => {
   // requestAnimationFrame starts ticking as soon as the page is loaded. We'll need
@@ -131,7 +139,7 @@ const useInterpolate = (
         // if our current time < duration, we're still interpolating.
         // get newDelta values, call the setter with them, and save them along
         // with requesting a new frame.
-        if (time < duration) {
+        if (time < duration || --loop) {
           const newDelta = getDelta({
             from: prevVals,
             to: current,
@@ -142,6 +150,11 @@ const useInterpolate = (
           lastFrame.current.delta = newDelta
 
           lastFrame.current.frame = requestAnimationFrame(animate)
+
+          if (loop && time >= duration) {
+            previous.current = prevVals
+            startTime.current = undefined
+          }
         } else {
           // otherwise, we've the duration. So we just call the setter with our final
           // values, update our previous value, and wipe out the last frame.


### PR DESCRIPTION
Added simple animation loops.

useInterpolate's options has now accepts a `loop` parameter.

If it's 0, it's the default behavior - run the interpolation once.
> 0 re-runs it _from the beginning_ the specified number of times. So `loop : 3` runs it 3x.
-1 re-runs it _from the beginning_ nonstop.